### PR TITLE
JavaScript candy_jar solution

### DIFF
--- a/questions/candy_jar/solution/candy_jar.js
+++ b/questions/candy_jar/solution/candy_jar.js
@@ -1,0 +1,11 @@
+function averageCandyJar([ size, ...info ]) {
+  let candy = 0;
+
+  for (const [start, end, count] of info) {
+    candy += count * (end - (start - 1));
+  }
+
+  return candy / size;
+}
+
+console.log(averageCandyJar([5, [1, 2, 100], [2, 5, 100], [3, 4, 100]]) === 160);


### PR DESCRIPTION
Doesn't keep track of actual jars, instead just adds all of the candies together because you only need the average.